### PR TITLE
Runtime instance tracker

### DIFF
--- a/arwen/contexts/instanceTracker.go
+++ b/arwen/contexts/instanceTracker.go
@@ -140,7 +140,7 @@ func (tracker *instanceTracker) UseWarmInstance(codeHash []byte) bool {
 }
 
 func (tracker *instanceTracker) ForceCleanInstance() {
-	if check.IfNil(tracker.Instance()) {
+	if check.IfNil(tracker.instance) {
 		logRuntime.Trace("cannot clean, instance already nil")
 		return
 	}
@@ -203,16 +203,27 @@ func (tracker *instanceTracker) SetNewInstance(instance wasmer.InstanceHandler, 
 }
 
 func (tracker *instanceTracker) ReplaceInstance(instance wasmer.InstanceHandler) {
+	tracker.instance = instance
+
+	if check.IfNil(tracker.instance) {
+		logRuntime.Trace("ReplaceInstance: current instance is nil")
+		return
+	}
+
 	if !tracker.instance.AlreadyCleaned() {
 		logRuntime.Trace("running instance about to be replaced without cleaning",
 			"id", tracker.instance.Id(),
 			"stacked", tracker.isInstanceOnTheStack(instance),
 		)
 	}
-	tracker.instance = instance
 }
 
 func (tracker *instanceTracker) UnsetInstance() {
+	if check.IfNil(tracker.instance) {
+		logRuntime.Trace("UnsetInstance: current instance is nil")
+		return
+	}
+
 	if !tracker.instance.AlreadyCleaned() {
 		logRuntime.Trace("running instance about to be unset without cleaning",
 			"id", tracker.instance.Id(),

--- a/arwen/contexts/instanceTracker.go
+++ b/arwen/contexts/instanceTracker.go
@@ -206,6 +206,7 @@ func (tracker *instanceTracker) ReplaceInstance(instance wasmer.InstanceHandler)
 	if !tracker.instance.AlreadyCleaned() {
 		logRuntime.Trace("running instance about to be replaced without cleaning",
 			"id", tracker.instance.Id(),
+			"stacked", tracker.isInstanceOnTheStack(instance),
 		)
 	}
 	tracker.instance = instance
@@ -215,6 +216,7 @@ func (tracker *instanceTracker) UnsetInstance() {
 	if !tracker.instance.AlreadyCleaned() {
 		logRuntime.Trace("running instance about to be unset without cleaning",
 			"id", tracker.instance.Id(),
+			"stacked", tracker.isInstanceOnTheStack(tracker.instance),
 		)
 	}
 	tracker.instance = nil
@@ -242,6 +244,16 @@ func (tracker *instanceTracker) IsCodeHashOnTheStack(codeHash []byte) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func (tracker *instanceTracker) isInstanceOnTheStack(instance wasmer.InstanceHandler) bool {
+	for _, stackedInstance := range tracker.instanceStack {
+		if stackedInstance.Id() == instance.Id() {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/arwen/contexts/instanceTracker.go
+++ b/arwen/contexts/instanceTracker.go
@@ -1,0 +1,265 @@
+package contexts
+
+import (
+	"bytes"
+
+	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/storage"
+	"github.com/ElrondNetwork/elrond-go-core/storage/lrucache"
+	"github.com/ElrondNetwork/wasm-vm-v1_4/arwen"
+	"github.com/ElrondNetwork/wasm-vm-v1_4/wasmer"
+)
+
+type instanceCacheLevel int
+
+const (
+	Warm instanceCacheLevel = iota
+	Precompiled
+	Bytecode
+)
+
+var _ arwen.StateStack = (*instanceTracker)(nil)
+
+type instanceTracker struct {
+	codeHash            []byte
+	numRunningInstances int
+	warmInstanceCache   storage.Cacher
+	instance            wasmer.InstanceHandler
+	cacheLevel          instanceCacheLevel
+	instanceStack       []wasmer.InstanceHandler
+	codeHashStack       [][]byte
+}
+
+func NewInstanceTracker() (*instanceTracker, error) {
+	tracker := &instanceTracker{
+		instanceStack:       make([]wasmer.InstanceHandler, 0),
+		numRunningInstances: 0,
+	}
+
+	var err error
+	instanceEvictedCallback := tracker.makeInstanceEvictionCallback()
+	tracker.warmInstanceCache, err = lrucache.NewCacheWithEviction(warmCacheSize, instanceEvictedCallback)
+	if err != nil {
+		return nil, err
+	}
+
+	return tracker, nil
+}
+
+func (tracker *instanceTracker) InitState() {
+	tracker.codeHash = make([]byte, 0)
+}
+
+func (tracker *instanceTracker) PushState() {
+	tracker.instanceStack = append(tracker.instanceStack, tracker.instance)
+	tracker.codeHashStack = append(tracker.codeHashStack, tracker.codeHash)
+	logRuntime.Trace("pushing instance", "id", tracker.instance.Id(), "codeHash", tracker.codeHash)
+}
+
+func (tracker *instanceTracker) PopSetActiveState() {
+	instanceStackLen := len(tracker.instanceStack)
+	if instanceStackLen == 0 {
+		return
+	}
+
+	prevInstance := tracker.instanceStack[instanceStackLen-1]
+	tracker.instanceStack = tracker.instanceStack[:instanceStackLen-1]
+
+	if prevInstance == tracker.instance {
+		// The current Wasmer instance was previously pushed on the instance stack,
+		// but a new Wasmer instance has not been created in the meantime. This
+		// means that the instance at the top of the stack is the same as the
+		// current instance, so it cannot be cleaned, because the execution will
+		// resume on it. Popping will therefore only remove the top of the stack,
+		// without cleaning anything.
+		return
+	}
+
+	if !check.IfNil(tracker.instance) {
+		if tracker.IsCodeHashOnTheStack(tracker.codeHash) {
+			if tracker.instance.Clean() {
+				tracker.updateNumRunningInstances(-1)
+			}
+		}
+
+		logRuntime.Trace("pop instance", "id", tracker.instance.Id(), "codeHash", tracker.codeHash)
+	}
+
+	tracker.ReplaceInstance(prevInstance)
+
+	prevCodeHash := tracker.codeHashStack[instanceStackLen-1]
+	tracker.codeHashStack = tracker.codeHashStack[:instanceStackLen-1]
+	tracker.codeHash = prevCodeHash
+}
+
+func (tracker *instanceTracker) PopDiscard() {
+}
+
+// ClearStateStack reinitializes the state stack.
+func (tracker *instanceTracker) ClearStateStack() {
+	tracker.codeHashStack = make([][]byte, 0)
+	tracker.instanceStack = make([]wasmer.InstanceHandler, 0)
+}
+
+func (tracker *instanceTracker) StackSize() uint64 {
+	return uint64(len(tracker.instanceStack))
+}
+
+func (tracker *instanceTracker) Instance() wasmer.InstanceHandler {
+	return tracker.instance
+}
+
+func (tracker *instanceTracker) CodeHash() []byte {
+	return tracker.codeHash
+}
+
+func (tracker *instanceTracker) ClearWarmInstanceCache() {
+	tracker.warmInstanceCache.Clear()
+}
+
+func (tracker *instanceTracker) UseWarmInstance(codeHash []byte) bool {
+	cachedObject, ok := tracker.warmInstanceCache.Get(codeHash)
+	if !ok {
+		return false
+	}
+
+	instance, ok := cachedObject.(wasmer.InstanceHandler)
+	if !ok {
+		return false
+	}
+
+	ok = instance.Reset()
+	if !ok {
+		// we must remove instance, which cleans it to free the memory
+		tracker.warmInstanceCache.Remove(codeHash)
+		return false
+	}
+
+	tracker.SetNewInstance(instance, Warm)
+	return true
+}
+
+func (tracker *instanceTracker) ForceCleanInstance() {
+	if check.IfNil(tracker.Instance()) {
+		logRuntime.Trace("cannot clean, instance already nil")
+		return
+	}
+
+	if tracker.IsCodeHashOnTheStack(tracker.codeHash) {
+		if tracker.instance.Clean() {
+			tracker.updateNumRunningInstances(-1)
+		}
+	} else {
+		tracker.warmInstanceCache.Remove(tracker.codeHash)
+	}
+	tracker.UnsetInstance()
+
+	numWarmInstances, numColdInstances := tracker.NumRunningInstances()
+	logRuntime.Trace("instance cleaned; num instances", "warm", numWarmInstances, "cold", numColdInstances)
+
+}
+
+func (tracker *instanceTracker) SaveAsWarmInstance() {
+	lenCacheBeforeSaving := tracker.warmInstanceCache.Len()
+
+	codeHashInWarmCache := tracker.warmInstanceCache.Has(tracker.codeHash)
+	if !codeHashInWarmCache {
+		logRuntime.Trace("warm instance not found, saving",
+			"id", tracker.instance.Id(),
+			"codeHash", tracker.codeHash,
+		)
+		tracker.warmInstanceCache.Put(
+			tracker.codeHash,
+			tracker.instance,
+			1,
+		)
+	} else {
+		tracker.updateNumRunningInstances(-1)
+		logRuntime.Trace("warm instance already in cache", "id", tracker.instance.Id())
+	}
+
+	lenCacheAfterSaving := tracker.warmInstanceCache.Len()
+	logRuntime.Trace("save warm instance length",
+		"before", lenCacheBeforeSaving,
+		"after", lenCacheAfterSaving,
+	)
+
+	logRuntime.Trace("save warm instance",
+		"id", tracker.instance.Id(),
+		"codeHash", tracker.codeHash,
+	)
+}
+
+func (tracker *instanceTracker) SetCodeHash(codeHash []byte) {
+	tracker.codeHash = codeHash
+}
+
+func (tracker *instanceTracker) SetNewInstance(instance wasmer.InstanceHandler, cacheLevel instanceCacheLevel) {
+	tracker.ReplaceInstance(instance)
+	tracker.cacheLevel = cacheLevel
+	if cacheLevel != Warm {
+		tracker.updateNumRunningInstances(+1)
+	}
+}
+
+func (tracker *instanceTracker) ReplaceInstance(instance wasmer.InstanceHandler) {
+	if !tracker.instance.AlreadyCleaned() {
+		logRuntime.Trace("running instance about to be replaced without cleaning",
+			"id", tracker.instance.Id(),
+		)
+	}
+	tracker.instance = instance
+}
+
+func (tracker *instanceTracker) UnsetInstance() {
+	if !tracker.instance.AlreadyCleaned() {
+		logRuntime.Trace("running instance about to be unset without cleaning",
+			"id", tracker.instance.Id(),
+		)
+	}
+	tracker.instance = nil
+}
+
+func (tracker *instanceTracker) LogCounts() {
+	warm, cold := tracker.NumRunningInstances()
+	logRuntime.Trace("num instances after starting new one",
+		"warm", warm,
+		"cold", cold,
+		"total", tracker.numRunningInstances,
+	)
+}
+
+// NumRunningInstances returns the number of currently running instances (cold and warm)
+func (tracker *instanceTracker) NumRunningInstances() (int, int) {
+	numWarmInstances := tracker.warmInstanceCache.Len()
+	numColdInstances := tracker.numRunningInstances - numWarmInstances
+	return numWarmInstances, numColdInstances
+}
+
+func (tracker *instanceTracker) IsCodeHashOnTheStack(codeHash []byte) bool {
+	for _, stackedCodeHash := range tracker.codeHashStack {
+		if bytes.Equal(codeHash, stackedCodeHash) {
+			return true
+		}
+	}
+	return false
+}
+
+func (tracker *instanceTracker) makeInstanceEvictionCallback() func(interface{}, interface{}) {
+	return func(_ interface{}, value interface{}) {
+		instance, ok := value.(wasmer.InstanceHandler)
+		if !ok {
+			return
+		}
+
+		logRuntime.Trace("evicted instance", "id", instance.Id())
+		if instance.Clean() {
+			tracker.updateNumRunningInstances(-1)
+		}
+	}
+}
+
+func (tracker *instanceTracker) updateNumRunningInstances(delta int) {
+	tracker.numRunningInstances += delta
+	logRuntime.Trace("num running instances updated", "delta", delta)
+}

--- a/arwen/contexts/instanceTracker.go
+++ b/arwen/contexts/instanceTracker.go
@@ -76,7 +76,9 @@ func (tracker *instanceTracker) PopSetActiveState() {
 	}
 
 	if !check.IfNil(tracker.instance) {
-		if tracker.IsCodeHashOnTheStack(tracker.codeHash) {
+		onStack := tracker.IsCodeHashOnTheStack(tracker.codeHash)
+		cold := !WarmInstancesEnabled
+		if onStack || cold {
 			if tracker.instance.Clean() {
 				tracker.updateNumRunningInstances(-1)
 			}
@@ -145,7 +147,9 @@ func (tracker *instanceTracker) ForceCleanInstance() {
 		return
 	}
 
-	if tracker.IsCodeHashOnTheStack(tracker.codeHash) {
+	onStack := tracker.IsCodeHashOnTheStack(tracker.codeHash)
+	cold := !WarmInstancesEnabled
+	if onStack || cold {
 		if tracker.instance.Clean() {
 			tracker.updateNumRunningInstances(-1)
 		}
@@ -206,7 +210,7 @@ func (tracker *instanceTracker) ReplaceInstance(instance wasmer.InstanceHandler)
 	tracker.instance = instance
 
 	if check.IfNil(tracker.instance) {
-		logRuntime.Trace("ReplaceInstance: current instance is nil")
+		logRuntime.Trace("ReplaceInstance: current instance is already nil")
 		return
 	}
 
@@ -220,7 +224,7 @@ func (tracker *instanceTracker) ReplaceInstance(instance wasmer.InstanceHandler)
 
 func (tracker *instanceTracker) UnsetInstance() {
 	if check.IfNil(tracker.instance) {
-		logRuntime.Trace("UnsetInstance: current instance is nil")
+		logRuntime.Trace("UnsetInstance: current instance is already nil")
 		return
 	}
 

--- a/arwen/contexts/instanceTracker.go
+++ b/arwen/contexts/instanceTracker.go
@@ -28,15 +28,12 @@ type instanceTracker struct {
 	cacheLevel          instanceCacheLevel
 	instanceStack       []wasmer.InstanceHandler
 	codeHashStack       [][]byte
-
-	usedWarmInstances [][]byte
 }
 
 func NewInstanceTracker() (*instanceTracker, error) {
 	tracker := &instanceTracker{
 		instanceStack:       make([]wasmer.InstanceHandler, 0),
 		numRunningInstances: 0,
-		usedWarmInstances:   make([][]byte, 0),
 	}
 
 	var err error
@@ -128,31 +125,6 @@ func (tracker *instanceTracker) ClearWarmInstanceCache() {
 	}
 }
 
-func (tracker *instanceTracker) ResetUsedWarmInstances() {
-	logRuntime.Trace("resetting used warm instances", "n", len(tracker.usedWarmInstances))
-	for _, codeHash := range tracker.usedWarmInstances {
-		cachedObject, ok := tracker.warmInstanceCache.Get(codeHash)
-		if !ok {
-			logRuntime.Trace("incorrect used codeHash")
-			continue
-		}
-		instance, ok := cachedObject.(wasmer.InstanceHandler)
-		if !ok {
-			logRuntime.Trace("invalid used instance object")
-			continue
-		}
-		ok = instance.Reset()
-		if !ok {
-			// we must remove instance, which cleans it to free the memory
-			logRuntime.Trace("used instance could not be reset, removing...")
-			tracker.warmInstanceCache.Remove(codeHash)
-			continue
-		}
-		logRuntime.Trace("used instance reset", "id", instance.Id(), "codeHash", codeHash)
-	}
-	tracker.usedWarmInstances = make([][]byte, 0)
-}
-
 func (tracker *instanceTracker) UseWarmInstance(codeHash []byte) bool {
 	cachedObject, ok := tracker.warmInstanceCache.Get(codeHash)
 	if !ok {
@@ -172,7 +144,6 @@ func (tracker *instanceTracker) UseWarmInstance(codeHash []byte) bool {
 	}
 
 	tracker.SetNewInstance(instance, Warm)
-	tracker.recordUsedWarmInstance(codeHash)
 	return true
 }
 
@@ -309,11 +280,6 @@ func (tracker *instanceTracker) isInstanceOnTheStack(instance wasmer.InstanceHan
 	}
 
 	return false
-}
-
-func (tracker *instanceTracker) recordUsedWarmInstance(codeHash []byte) {
-	tracker.usedWarmInstances = append(tracker.usedWarmInstances, codeHash)
-	logRuntime.Trace("recording used warm instance", "codeHash", codeHash)
 }
 
 func (tracker *instanceTracker) makeInstanceEvictionCallback() func(interface{}, interface{}) {

--- a/arwen/contexts/instanceTracker.go
+++ b/arwen/contexts/instanceTracker.go
@@ -13,8 +13,13 @@ import (
 type instanceCacheLevel int
 
 const (
+	// Warm indicates that the instance to track is a warm instance
 	Warm instanceCacheLevel = iota
+
+	// Precompiled indicates that the instance to track is cold and has been created from precompiled code
 	Precompiled
+
+	// Bytecode indicates that the instance to track is cold and has been created from raw bytecode
 	Bytecode
 )
 
@@ -30,6 +35,7 @@ type instanceTracker struct {
 	codeHashStack       [][]byte
 }
 
+// NewInstanceTracker creates a new instanceTracker instance
 func NewInstanceTracker() (*instanceTracker, error) {
 	tracker := &instanceTracker{
 		instanceStack:       make([]wasmer.InstanceHandler, 0),
@@ -81,8 +87,8 @@ func (tracker *instanceTracker) PopSetActiveState() {
 
 	if !check.IfNil(tracker.instance) {
 		onStack := tracker.IsCodeHashOnTheStack(tracker.codeHash)
-		cold := !WarmInstancesEnabled
-		if onStack || cold {
+		coldOnlyEnabled := !WarmInstancesEnabled
+		if onStack || coldOnlyEnabled {
 			if tracker.instance.Clean() {
 				tracker.updateNumRunningInstances(-1)
 			}
@@ -154,8 +160,8 @@ func (tracker *instanceTracker) ForceCleanInstance() {
 	}
 
 	onStack := tracker.IsCodeHashOnTheStack(tracker.codeHash)
-	cold := !WarmInstancesEnabled
-	if onStack || cold {
+	coldOnlyEnabled := !WarmInstancesEnabled
+	if onStack || coldOnlyEnabled {
 		if tracker.instance.Clean() {
 			tracker.updateNumRunningInstances(-1)
 		}

--- a/arwen/contexts/instanceTracker_test.go
+++ b/arwen/contexts/instanceTracker_test.go
@@ -1,0 +1,28 @@
+package contexts
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/wasm-vm-v1_4/wasmer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceTracker_UnsetInstance_AlreadyNil_Ok(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	iTracker.instance = nil
+	iTracker.UnsetInstance()
+	require.Nil(t, iTracker.instance)
+}
+
+func TestInstanceTracker_UnsetInstance_Ok(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	iTracker.instance = &wasmer.Instance{
+		AlreadyClean: true,
+	}
+	iTracker.UnsetInstance()
+	require.Nil(t, iTracker.instance)
+}

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -37,6 +37,8 @@ type runtimeContext struct {
 	verifyCode         bool
 	maxWasmerInstances uint64
 
+	numRunningInstances int
+
 	warmInstanceCache storage.Cacher
 
 	stateStack    []*runtimeContext
@@ -59,12 +61,13 @@ func NewRuntimeContext(
 	scAPINames := host.GetAPIMethods().Names()
 
 	context := &runtimeContext{
-		host:          host,
-		vmType:        vmType,
-		stateStack:    make([]*runtimeContext, 0),
-		instanceStack: make([]wasmer.InstanceHandler, 0),
-		validator:     newWASMValidator(scAPINames, builtInFuncContainer),
-		errors:        nil,
+		host:                host,
+		vmType:              vmType,
+		stateStack:          make([]*runtimeContext, 0),
+		instanceStack:       make([]wasmer.InstanceHandler, 0),
+		validator:           newWASMValidator(scAPINames, builtInFuncContainer),
+		numRunningInstances: 0,
+		errors:              nil,
 	}
 
 	var err error
@@ -97,6 +100,7 @@ func (context *runtimeContext) InitState() {
 	context.callFunction = ""
 	context.verifyCode = false
 	context.readOnly = false
+	context.numRunningInstances = 0
 	context.asyncCallInfo = nil
 	context.asyncContextInfo = &arwen.AsyncContextInfo{
 		AsyncContextMap: make(map[string]*arwen.AsyncContext),
@@ -140,10 +144,17 @@ func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uin
 	}
 	compiledCodeUsed := context.makeInstanceFromCompiledCode(gasLimit, newCode)
 	if compiledCodeUsed {
+		context.numRunningInstances++
 		return nil
 	}
 
-	return context.makeInstanceFromContractByteCode(contract, gasLimit, newCode)
+	err := context.makeInstanceFromContractByteCode(contract, gasLimit, newCode)
+	if err != nil {
+		return err
+	}
+
+	context.numRunningInstances++
+	return nil
 }
 
 func (context *runtimeContext) makeInstanceFromCompiledCode(gasLimit uint64, newCode bool) bool {
@@ -443,6 +454,7 @@ func (context *runtimeContext) popInstance() {
 	if !check.IfNil(context.instance) {
 		if context.isCodeHashOnTheStack(context.codeHash) {
 			context.instance.Clean()
+			context.numRunningInstances--
 		}
 	}
 
@@ -915,8 +927,9 @@ func (context *runtimeContext) CleanInstance() {
 	}
 
 	context.instance.Clean()
-
 	context.instance = nil
+	context.numRunningInstances--
+
 	logRuntime.Trace("instance cleaned")
 }
 
@@ -1178,6 +1191,13 @@ func (context *runtimeContext) AddError(err error, otherInfo ...string) {
 // GetAllErrors returns all the errors stored on the RuntimeContext
 func (context *runtimeContext) GetAllErrors() error {
 	return context.errors
+}
+
+// NumRunningInstances returns the number of currently running instances (cold and warm)
+func (context *runtimeContext) NumRunningInstances() (int, int) {
+	numWarmInstances := context.warmInstanceCache.Len()
+	numColdInstances := context.numRunningInstances - numWarmInstances
+	return numWarmInstances, numColdInstances
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -22,6 +22,7 @@ var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
 const warmCacheSize = 50
 
+// WarmInstancesEnabled controls the usage of warm instances
 const WarmInstancesEnabled = false
 
 type runtimeContext struct {

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -9,8 +9,6 @@ import (
 	"unsafe"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
-	"github.com/ElrondNetwork/elrond-go-core/storage"
-	"github.com/ElrondNetwork/elrond-go-core/storage/lrucache"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/wasm-vm-v1_4/arwen"
@@ -26,10 +24,8 @@ const warmCacheSize = 100
 
 type runtimeContext struct {
 	host               arwen.VMHost
-	instance           wasmer.InstanceHandler
 	vmInput            *vmcommon.ContractCallInput
 	codeAddress        []byte
-	codeHash           []byte
 	codeSize           uint64
 	callFunction       string
 	vmType             []byte
@@ -37,12 +33,9 @@ type runtimeContext struct {
 	verifyCode         bool
 	maxWasmerInstances uint64
 
-	numRunningInstances int
+	iTracker *instanceTracker
 
-	warmInstanceCache storage.Cacher
-
-	stateStack    []*runtimeContext
-	instanceStack []wasmer.InstanceHandler
+	stateStack []*runtimeContext
 
 	asyncCallInfo    *arwen.AsyncCallInfo
 	asyncContextInfo *arwen.AsyncContextInfo
@@ -61,21 +54,18 @@ func NewRuntimeContext(
 	scAPINames := host.GetAPIMethods().Names()
 
 	context := &runtimeContext{
-		host:                host,
-		vmType:              vmType,
-		stateStack:          make([]*runtimeContext, 0),
-		instanceStack:       make([]wasmer.InstanceHandler, 0),
-		validator:           newWASMValidator(scAPINames, builtInFuncContainer),
-		numRunningInstances: 0,
-		errors:              nil,
+		host:       host,
+		vmType:     vmType,
+		stateStack: make([]*runtimeContext, 0),
+		validator:  newWASMValidator(scAPINames, builtInFuncContainer),
+		errors:     nil,
 	}
 
-	var err error
-	instanceEvictedCallback := context.makeInstanceEvictionCallback()
-	context.warmInstanceCache, err = lrucache.NewCacheWithEviction(warmCacheSize, instanceEvictedCallback)
+	iTracker, err := NewInstanceTracker()
 	if err != nil {
 		return nil, err
 	}
+	context.iTracker = iTracker
 
 	context.instanceBuilder = &WasmerInstanceBuilder{}
 	context.InitState()
@@ -83,25 +73,10 @@ func NewRuntimeContext(
 	return context, nil
 }
 
-func (context *runtimeContext) makeInstanceEvictionCallback() func(interface{}, interface{}) {
-	return func(_ interface{}, value interface{}) {
-		instance, ok := value.(wasmer.InstanceHandler)
-		if !ok {
-			return
-		}
-
-		logRuntime.Trace("evicted instance", "id", instance.Id())
-		if instance.Clean() {
-			context.updateNumRunningInstances(-1)
-		}
-	}
-}
-
 // InitState initializes all the contexts fields with default data.
 func (context *runtimeContext) InitState() {
 	context.vmInput = &vmcommon.ContractCallInput{}
 	context.codeAddress = make([]byte, 0)
-	context.codeHash = make([]byte, 0)
 	context.callFunction = ""
 	context.verifyCode = false
 	context.readOnly = false
@@ -109,6 +84,7 @@ func (context *runtimeContext) InitState() {
 	context.asyncContextInfo = &arwen.AsyncContextInfo{
 		AsyncContextMap: make(map[string]*arwen.AsyncContext),
 	}
+	context.iTracker.InitState()
 	context.errors = nil
 
 	logRuntime.Trace("init state")
@@ -116,8 +92,8 @@ func (context *runtimeContext) InitState() {
 
 // ClearWarmInstanceCache clears all elements from warm instance cache
 func (context *runtimeContext) ClearWarmInstanceCache() {
-	context.warmInstanceCache.Clear()
-	context.instance = nil
+	context.iTracker.ClearWarmInstanceCache()
+	context.iTracker.UnsetInstance()
 }
 
 // ReplaceInstanceBuilder replaces the instance builder, allowing the creation
@@ -128,7 +104,7 @@ func (context *runtimeContext) ReplaceInstanceBuilder(builder arwen.InstanceBuil
 
 // StartWasmerInstance creates a new wasmer instance if the maxWasmerInstances has not been reached.
 func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uint64, newCode bool) error {
-	context.instance = nil
+	context.iTracker.UnsetInstance()
 
 	if context.RunningInstancesCount() >= context.maxWasmerInstances {
 		logRuntime.Trace("create instance", "error", arwen.ErrMaxInstancesReached)
@@ -137,44 +113,34 @@ func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uin
 
 	blockchain := context.host.Blockchain()
 	codeHash := blockchain.GetCodeHash(context.codeAddress)
-	context.codeHash = codeHash
+	context.iTracker.SetCodeHash(codeHash)
 
 	defer func() {
-		warm, cold := context.NumRunningInstances()
-		logRuntime.Trace("num instances after starting new one",
-			"warm", warm,
-			"cold", cold,
-			"total", context.numRunningInstances,
-			"new code", newCode,
-		)
+		context.iTracker.LogCounts()
+		logRuntime.Trace("code was new", "new", newCode)
 	}()
 
 	warmInstanceUsed := context.useWarmInstanceIfExists(gasLimit, newCode)
 	if warmInstanceUsed {
 		return nil
 	}
+
 	compiledCodeUsed := context.makeInstanceFromCompiledCode(gasLimit, newCode)
 	if compiledCodeUsed {
-		context.updateNumRunningInstances(+1)
 		return nil
 	}
 
-	err := context.makeInstanceFromContractByteCode(contract, gasLimit, newCode)
-	if err != nil {
-		return err
-	}
-
-	context.updateNumRunningInstances(+1)
-	return nil
+	return context.makeInstanceFromContractByteCode(contract, gasLimit, newCode)
 }
 
 func (context *runtimeContext) makeInstanceFromCompiledCode(gasLimit uint64, newCode bool) bool {
-	if newCode || len(context.codeHash) == 0 {
+	codeHash := context.iTracker.CodeHash()
+	if newCode || len(codeHash) == 0 {
 		return false
 	}
 
 	blockchain := context.host.Blockchain()
-	found, compiledCode := blockchain.GetCompiledCode(context.codeHash)
+	found, compiledCode := blockchain.GetCompiledCode(codeHash)
 	if !found {
 		logRuntime.Trace("instance creation", "code", "cached compilation", "error", "compiled code was not found")
 		return false
@@ -196,16 +162,16 @@ func (context *runtimeContext) makeInstanceFromCompiledCode(gasLimit uint64, new
 		return false
 	}
 
-	context.instance = newInstance
+	context.iTracker.SetNewInstance(newInstance, Precompiled)
 
 	hostReference := uintptr(unsafe.Pointer(&context.host))
-	context.instance.SetContextData(hostReference)
+	context.iTracker.Instance().SetContextData(hostReference)
 	context.verifyCode = false
 
 	context.saveWarmInstance()
 	logRuntime.Trace("start instance", "from", "cached compilation",
-		"id", context.instance.Id(),
-		"codeHash", context.codeHash,
+		"id", context.iTracker.Instance().Id(),
+		"codeHash", context.iTracker.Instance(),
 	)
 	return true
 }
@@ -223,24 +189,25 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 	}
 	newInstance, err := context.instanceBuilder.NewInstanceWithOptions(contract, options)
 	if err != nil {
-		context.instance = nil
+		context.iTracker.UnsetInstance()
 		logRuntime.Trace("instance creation", "code", "bytecode", "error", err)
 		return err
 	}
 
-	context.instance = newInstance
+	context.iTracker.SetNewInstance(newInstance, Bytecode)
 
-	if newCode || len(context.codeHash) == 0 {
-		context.codeHash, err = context.host.Crypto().Sha256(contract)
+	if newCode || len(context.iTracker.CodeHash()) == 0 {
+		codeHash, err := context.host.Crypto().Sha256(contract)
 		if err != nil {
 			context.CleanInstance()
 			logRuntime.Error("instance creation", "code", "bytecode", "error", err)
 			return err
 		}
+		context.iTracker.SetCodeHash(codeHash)
 	}
 
 	hostReference := uintptr(unsafe.Pointer(&context.host))
-	context.instance.SetContextData(hostReference)
+	context.iTracker.Instance().SetContextData(hostReference)
 
 	if newCode {
 		err = context.VerifyContractCode()
@@ -253,8 +220,8 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 
 	logRuntime.Trace("start instance",
 		"from", "bytecode",
-		"id", context.instance.Id(),
-		"codeHash", context.codeHash,
+		"id", context.iTracker.Instance().Id(),
+		"codeHash", context.iTracker.CodeHash(),
 	)
 	context.saveCompiledCode()
 
@@ -262,39 +229,27 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 }
 
 func (context *runtimeContext) useWarmInstanceIfExists(gasLimit uint64, newCode bool) bool {
-	if newCode || len(context.codeHash) == 0 {
+	codeHash := context.iTracker.CodeHash()
+	if newCode || len(codeHash) == 0 {
 		return false
 	}
 
 	if context.isContractOrCodeHashOnTheStack() {
 		return false
 	}
-	cachedObject, ok := context.warmInstanceCache.Get(context.codeHash)
+	ok := context.iTracker.UseWarmInstance(codeHash)
 	if !ok {
 		return false
 	}
 
-	instance, ok := cachedObject.(wasmer.InstanceHandler)
-	if !ok {
-		return false
-	}
-
-	ok = instance.Reset()
-	if !ok {
-		// we must remove instance, which cleans it to free the memory
-		context.warmInstanceCache.Remove(context.codeHash)
-		return false
-	}
-
-	context.instance = instance
 	context.SetPointsUsed(0)
-	context.instance.SetGasLimit(gasLimit)
+	context.iTracker.Instance().SetGasLimit(gasLimit)
 	context.SetRuntimeBreakpointValue(arwen.BreakpointNone)
 
 	hostReference := uintptr(unsafe.Pointer(&context.host))
-	context.instance.SetContextData(hostReference)
+	context.iTracker.Instance().SetContextData(hostReference)
 	context.verifyCode = false
-	logRuntime.Trace("start instance", "from", "warm", "id", context.instance.Id())
+	logRuntime.Trace("start instance", "from", "warm", "id", context.iTracker.Instance().Id())
 	return true
 }
 
@@ -317,17 +272,18 @@ func (context *runtimeContext) GetSCCodeSize() uint64 {
 }
 
 func (context *runtimeContext) saveCompiledCode() {
-	compiledCode, err := context.instance.Cache()
+	compiledCode, err := context.iTracker.Instance().Cache()
 	if err != nil {
 		logRuntime.Error("getCompiledCode from instance", "error", err)
 		return
 	}
 
+	codeHash := context.iTracker.CodeHash()
 	blockchain := context.host.Blockchain()
-	blockchain.SaveCompiledCode(context.codeHash, compiledCode)
-	logRuntime.Trace("save compiled code", "codeHash", context.codeHash)
+	blockchain.SaveCompiledCode(codeHash, compiledCode)
+	logRuntime.Trace("save compiled code", "codeHash", codeHash)
 
-	found, _ := blockchain.GetCompiledCode(context.codeHash)
+	found, _ := blockchain.GetCompiledCode(codeHash)
 	if !found {
 		logRuntime.Trace("save compiled code silent fail, code hash not found")
 	}
@@ -340,34 +296,7 @@ func (context *runtimeContext) saveWarmInstance() {
 		return
 	}
 
-	lenCacheBeforeSaving := context.warmInstanceCache.Len()
-
-	codeHashInWarmCache := context.warmInstanceCache.Has(context.codeHash)
-	if !codeHashInWarmCache {
-		logRuntime.Trace("warm instance not found, saving",
-			"id", context.instance.Id(),
-			"codeHash", context.codeHash,
-		)
-		context.warmInstanceCache.Put(
-			context.codeHash,
-			context.instance,
-			1,
-		)
-	} else {
-		context.updateNumRunningInstances(-1)
-		logRuntime.Trace("warm instance already in cache", "id", context.instance.Id())
-	}
-
-	lenCacheAfterSaving := context.warmInstanceCache.Len()
-	logRuntime.Trace("save warm instance length",
-		"before", lenCacheBeforeSaving,
-		"after", lenCacheAfterSaving,
-	)
-
-	logRuntime.Trace("save warm instance",
-		"id", context.instance.Id(),
-		"codeHash", context.codeHash,
-	)
+	context.iTracker.SaveAsWarmInstance()
 }
 
 // MustVerifyNextContractCode sets the verifyCode field to true
@@ -409,7 +338,6 @@ func (context *runtimeContext) SetCustomCallFunction(callFunction string) {
 func (context *runtimeContext) PushState() {
 	newState := &runtimeContext{
 		codeAddress:      context.codeAddress,
-		codeHash:         context.codeHash,
 		callFunction:     context.callFunction,
 		readOnly:         context.readOnly,
 		asyncCallInfo:    context.asyncCallInfo,
@@ -441,7 +369,6 @@ func (context *runtimeContext) PopSetActiveState() {
 
 	context.SetVMInput(prevState.vmInput)
 	context.codeAddress = prevState.codeAddress
-	context.codeHash = prevState.codeHash
 	context.callFunction = prevState.callFunction
 	context.readOnly = prevState.readOnly
 	context.asyncCallInfo = prevState.asyncCallInfo
@@ -455,7 +382,7 @@ func (context *runtimeContext) PopDiscard() {
 		return
 	}
 
-	context.popInstance()
+	context.iTracker.PopSetActiveState()
 
 	context.stateStack = context.stateStack[:stateStackLen-1]
 }
@@ -463,51 +390,23 @@ func (context *runtimeContext) PopDiscard() {
 // ClearStateStack reinitializes the state stack.
 func (context *runtimeContext) ClearStateStack() {
 	context.stateStack = make([]*runtimeContext, 0)
+	context.iTracker.ClearStateStack()
 }
 
 // pushInstance appends the current wasmer instance to the instance stack.
 func (context *runtimeContext) pushInstance() {
-	context.instanceStack = append(context.instanceStack, context.instance)
-	logRuntime.Trace("pushing instance", "id", context.instance.Id(), "codeHash", context.codeHash)
+	context.iTracker.PushState()
 }
 
 // popInstance removes the latest entry from the wasmer instance stack and sets it
 // as the current wasmer instance
 func (context *runtimeContext) popInstance() {
-	instanceStackLen := len(context.instanceStack)
-	if instanceStackLen == 0 {
-		return
-	}
-
-	prevInstance := context.instanceStack[instanceStackLen-1]
-	context.instanceStack = context.instanceStack[:instanceStackLen-1]
-
-	if prevInstance == context.instance {
-		// The current Wasmer instance was previously pushed on the instance stack,
-		// but a new Wasmer instance has not been created in the meantime. This
-		// means that the instance at the top of the stack is the same as the
-		// current instance, so it cannot be cleaned, because the execution will
-		// resume on it. Popping will therefore only remove the top of the stack,
-		// without cleaning anything.
-		return
-	}
-
-	if !check.IfNil(context.instance) {
-		if context.isCodeHashOnTheStack(context.codeHash) {
-			if context.instance.Clean() {
-				context.updateNumRunningInstances(-1)
-			}
-		}
-
-		logRuntime.Trace("pop instance", "id", context.instance.Id(), "codeHash", context.codeHash)
-	}
-
-	context.instance = prevInstance
+	context.iTracker.PopSetActiveState()
 }
 
 // RunningInstancesCount returns the length of the instance stack.
 func (context *runtimeContext) RunningInstancesCount() uint64 {
-	return uint64(len(context.instanceStack))
+	return context.iTracker.StackSize()
 }
 
 // GetVMType returns the vm type for the current context.
@@ -652,7 +551,7 @@ func (context *runtimeContext) FailExecution(err error) {
 	}
 
 	context.host.Output().SetReturnMessage(message)
-	if !check.IfNil(context.instance) {
+	if !check.IfNil(context.iTracker.Instance()) {
 		context.SetRuntimeBreakpointValue(breakpoint)
 	}
 
@@ -674,13 +573,13 @@ func (context *runtimeContext) SignalUserError(message string) {
 
 // SetRuntimeBreakpointValue sets the given value as a breakpoint value.
 func (context *runtimeContext) SetRuntimeBreakpointValue(value arwen.BreakpointValue) {
-	context.instance.SetBreakpointValue(uint64(value))
+	context.iTracker.Instance().SetBreakpointValue(uint64(value))
 	logRuntime.Trace("runtime breakpoint set", "breakpoint", value)
 }
 
 // GetRuntimeBreakpointValue returns the breakpoint value for the current wasmer instance.
 func (context *runtimeContext) GetRuntimeBreakpointValue() arwen.BreakpointValue {
-	return arwen.BreakpointValue(context.instance.GetBreakpointValue())
+	return arwen.BreakpointValue(context.iTracker.Instance().GetBreakpointValue())
 }
 
 // VerifyContractCode checks the current wasmer instance for enough memory and for correct functions.
@@ -691,13 +590,13 @@ func (context *runtimeContext) VerifyContractCode() error {
 
 	context.verifyCode = false
 
-	err := context.validator.verifyMemoryDeclaration(context.instance)
+	err := context.validator.verifyMemoryDeclaration(context.iTracker.Instance())
 	if err != nil {
 		logRuntime.Trace("verify contract code", "error", err)
 		return err
 	}
 
-	err = context.validator.verifyFunctions(context.instance)
+	err = context.validator.verifyFunctions(context.iTracker.Instance())
 	if err != nil {
 		logRuntime.Trace("verify contract code", "error", err)
 		return err
@@ -721,7 +620,7 @@ func (context *runtimeContext) VerifyContractCode() error {
 	}
 
 	if enableEpochsHandler.IsManagedCryptoAPIsFlagEnabled() {
-		err = context.validator.verifyProtectedFunctions(context.instance)
+		err = context.validator.verifyProtectedFunctions(context.iTracker.Instance())
 		if err != nil {
 			logRuntime.Trace("verify contract code", "error", err)
 			return err
@@ -734,31 +633,31 @@ func (context *runtimeContext) VerifyContractCode() error {
 }
 
 func (context *runtimeContext) checkBackwardCompatibility() error {
-	if context.instance.IsFunctionImported("mBufferSetByteSlice") {
+	if context.iTracker.Instance().IsFunctionImported("mBufferSetByteSlice") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("getESDTLocalRoles") {
+	if context.iTracker.Instance().IsFunctionImported("getESDTLocalRoles") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("validateTokenIdentifier") {
+	if context.iTracker.Instance().IsFunctionImported("validateTokenIdentifier") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedSha256") {
+	if context.iTracker.Instance().IsFunctionImported("managedSha256") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedKeccak256") {
+	if context.iTracker.Instance().IsFunctionImported("managedKeccak256") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("mBufferStorageLoadFromAddress") {
+	if context.iTracker.Instance().IsFunctionImported("mBufferStorageLoadFromAddress") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("cleanReturnData") {
+	if context.iTracker.Instance().IsFunctionImported("cleanReturnData") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("deleteFromReturnData") {
+	if context.iTracker.Instance().IsFunctionImported("deleteFromReturnData") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("completedTxEvent") {
+	if context.iTracker.Instance().IsFunctionImported("completedTxEvent") {
 		return arwen.ErrContractInvalid
 	}
 
@@ -766,130 +665,130 @@ func (context *runtimeContext) checkBackwardCompatibility() error {
 }
 
 func (context *runtimeContext) checkIfContainsNewManagedCryptoAPI() error {
-	if context.instance.IsFunctionImported("managedIsESDTFrozen") {
+	if context.iTracker.Instance().IsFunctionImported("managedIsESDTFrozen") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedIsESDTPaused") {
+	if context.iTracker.Instance().IsFunctionImported("managedIsESDTPaused") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedIsESDTLimitedTransfer") {
+	if context.iTracker.Instance().IsFunctionImported("managedIsESDTLimitedTransfer") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedBufferToHex") {
+	if context.iTracker.Instance().IsFunctionImported("managedBufferToHex") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigIntToString") {
+	if context.iTracker.Instance().IsFunctionImported("bigIntToString") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedRipemd160") {
+	if context.iTracker.Instance().IsFunctionImported("managedRipemd160") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedVerifyBLS") {
+	if context.iTracker.Instance().IsFunctionImported("managedVerifyBLS") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedVerifyEd25519") {
+	if context.iTracker.Instance().IsFunctionImported("managedVerifyEd25519") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedVerifySecp256k1") {
+	if context.iTracker.Instance().IsFunctionImported("managedVerifySecp256k1") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedVerifyCustomSecp256k1") {
+	if context.iTracker.Instance().IsFunctionImported("managedVerifyCustomSecp256k1") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedEncodeSecp256k1DerSignature") {
+	if context.iTracker.Instance().IsFunctionImported("managedEncodeSecp256k1DerSignature") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedScalarBaseMultEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedScalarBaseMultEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedScalarMultEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedScalarMultEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedMarshalEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedMarshalEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedUnmarshalEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedUnmarshalEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedMarshalCompressedEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedMarshalCompressedEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedUnmarshalCompressedEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedUnmarshalCompressedEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedGenerateKeyEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedGenerateKeyEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("managedCreateEC") {
+	if context.iTracker.Instance().IsFunctionImported("managedCreateEC") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("mBufferToBigFloat") {
+	if context.iTracker.Instance().IsFunctionImported("mBufferToBigFloat") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("mBufferFromBigFloat") {
+	if context.iTracker.Instance().IsFunctionImported("mBufferFromBigFloat") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatNewFromParts") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatNewFromParts") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatNewFromFrac") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatNewFromFrac") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatNewFromSci") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatNewFromSci") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatAdd") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatAdd") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatSub") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatSub") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatMul") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatMul") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatDiv") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatDiv") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatAbs") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatAbs") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatCmp") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatCmp") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatSign") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatSign") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatClone") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatClone") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatSqrt") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatSqrt") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatPow") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatPow") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatFloor") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatFloor") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatCeil") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatCeil") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatTruncate") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatTruncate") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatIsInt") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatIsInt") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatSetInt64") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatSetInt64") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatSetBigInt") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatSetBigInt") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatGetConstPi") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatGetConstPi") {
 		return arwen.ErrContractInvalid
 	}
-	if context.instance.IsFunctionImported("bigFloatGetConstE") {
+	if context.iTracker.Instance().IsFunctionImported("bigFloatGetConstE") {
 		return arwen.ErrContractInvalid
 	}
 
@@ -928,10 +827,10 @@ func (context *runtimeContext) ManagedBufferAPIErrorShouldFailExecution() bool {
 
 // GetPointsUsed returns the gas points used by the current wasmer instance.
 func (context *runtimeContext) GetPointsUsed() uint64 {
-	if context.instance == nil {
+	if context.iTracker.Instance() == nil {
 		return 0
 	}
-	return context.instance.GetPointsUsed()
+	return context.iTracker.Instance().GetPointsUsed()
 }
 
 // SetPointsUsed sets the given gas points as the gas points used by the current wasmer instance.
@@ -939,7 +838,7 @@ func (context *runtimeContext) SetPointsUsed(gasPoints uint64) {
 	if gasPoints > builtinMath.MaxInt64 {
 		gasPoints = builtinMath.MaxInt64
 	}
-	context.instance.SetPointsUsed(gasPoints)
+	context.iTracker.Instance().SetPointsUsed(gasPoints)
 }
 
 // ReadOnly returns true if the current context is readOnly
@@ -954,33 +853,17 @@ func (context *runtimeContext) SetReadOnly(readOnly bool) {
 
 // GetInstance returns the current wasmer instance
 func (context *runtimeContext) GetInstance() wasmer.InstanceHandler {
-	return context.instance
+	return context.iTracker.Instance()
 }
 
 // GetInstanceExports returns the current wasmer instance exports.
 func (context *runtimeContext) GetInstanceExports() wasmer.ExportsMap {
-	return context.instance.GetExports()
+	return context.iTracker.Instance().GetExports()
 }
 
 // CleanInstance cleans the current instance
 func (context *runtimeContext) CleanInstance() {
-	if check.IfNil(context.instance) {
-		logRuntime.Trace("cannot clean, instance already nil")
-		return
-	}
-
-	if context.isCodeHashOnTheStack(context.codeHash) {
-		if context.instance.Clean() {
-			context.updateNumRunningInstances(-1)
-		}
-	} else {
-		context.warmInstanceCache.Remove(context.codeHash)
-	}
-	context.instance = nil
-
-	numWarmInstances, numColdInstances := context.NumRunningInstances()
-	logRuntime.Trace("instance cleaned; num instances", "warm", numWarmInstances, "cold", numColdInstances)
-
+	context.iTracker.ForceCleanInstance()
 }
 
 // isContractOrCodeHashOnTheStack iterates over the state stack to find whether the
@@ -989,16 +872,7 @@ func (context *runtimeContext) isContractOrCodeHashOnTheStack() bool {
 	if context.isScAddressOnTheStack(context.codeAddress) {
 		return true
 	}
-	return context.isCodeHashOnTheStack(context.codeHash)
-}
-
-func (context *runtimeContext) isCodeHashOnTheStack(codeHash []byte) bool {
-	for _, state := range context.stateStack {
-		if bytes.Equal(codeHash, state.codeHash) {
-			return true
-		}
-	}
-	return false
+	return context.iTracker.IsCodeHashOnTheStack(context.iTracker.CodeHash())
 }
 
 func (context *runtimeContext) isScAddressOnTheStack(scAddress []byte) bool {
@@ -1012,7 +886,7 @@ func (context *runtimeContext) isScAddressOnTheStack(scAddress []byte) bool {
 
 // GetFunctionToCall returns the function to call from the wasmer instance exports.
 func (context *runtimeContext) GetFunctionToCall() (wasmer.ExportedFunctionCallback, error) {
-	exports := context.instance.GetExports()
+	exports := context.iTracker.Instance().GetExports()
 	logRuntime.Trace("get function to call", "function", context.callFunction)
 	if function, ok := exports[context.callFunction]; ok {
 		return function, nil
@@ -1029,7 +903,7 @@ func (context *runtimeContext) GetFunctionToCall() (wasmer.ExportedFunctionCallb
 
 // GetInitFunction returns the init function from the current wasmer instance exports.
 func (context *runtimeContext) GetInitFunction() wasmer.ExportedFunctionCallback {
-	exports := context.instance.GetExports()
+	exports := context.iTracker.Instance().GetExports()
 	if init, ok := exports[arwen.InitFunctionName]; ok {
 		return init
 	}
@@ -1120,13 +994,13 @@ func (context *runtimeContext) GetAsyncCallInfo() *arwen.AsyncCallInfo {
 
 // HasCallbackMethod returns true if the current wasmer instance exports has a callback method.
 func (context *runtimeContext) HasCallbackMethod() bool {
-	_, ok := context.instance.GetExports()[arwen.CallbackFunctionName]
+	_, ok := context.iTracker.Instance().GetExports()[arwen.CallbackFunctionName]
 	return ok
 }
 
 // IsFunctionImported returns true if the WASM module imports the specified function.
 func (context *runtimeContext) IsFunctionImported(name string) bool {
-	return context.instance.IsFunctionImported(name)
+	return context.iTracker.Instance().IsFunctionImported(name)
 }
 
 // MemLoad returns the contents from the given offset of the WASM memory.
@@ -1135,7 +1009,7 @@ func (context *runtimeContext) MemLoad(offset int32, length int32) ([]byte, erro
 		return []byte{}, nil
 	}
 
-	memory := context.instance.GetInstanceCtxMemory()
+	memory := context.iTracker.Instance().GetInstanceCtxMemory()
 	memoryView := memory.Data()
 	memoryLength := memory.Length()
 	requestedEnd := math.AddInt32(offset, length)
@@ -1190,7 +1064,7 @@ func (context *runtimeContext) MemStore(offset int32, data []byte) error {
 		return nil
 	}
 
-	memory := context.instance.GetInstanceCtxMemory()
+	memory := context.iTracker.Instance().GetInstanceCtxMemory()
 	memoryView := memory.Data()
 	memoryLength := memory.Length()
 	requestedEnd := math.AddInt32(offset, dataLength)
@@ -1245,14 +1119,7 @@ func (context *runtimeContext) GetAllErrors() error {
 
 // NumRunningInstances returns the number of currently running instances (cold and warm)
 func (context *runtimeContext) NumRunningInstances() (int, int) {
-	numWarmInstances := context.warmInstanceCache.Len()
-	numColdInstances := context.numRunningInstances - numWarmInstances
-	return numWarmInstances, numColdInstances
-}
-
-func (context *runtimeContext) updateNumRunningInstances(delta int) {
-	context.numRunningInstances += delta
-	logRuntime.Trace("num running instances updated", "delta", delta)
+	return context.iTracker.NumRunningInstances()
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -22,7 +22,7 @@ var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
 const warmCacheSize = 50
 
-const WarmInstancesEnabled = false
+const WarmInstancesEnabled = true
 
 type runtimeContext struct {
 	host               arwen.VMHost

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -22,7 +22,7 @@ var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
 const warmCacheSize = 50
 
-const WarmInstancesEnabled = true
+const WarmInstancesEnabled = false
 
 type runtimeContext struct {
 	host               arwen.VMHost

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -98,11 +98,6 @@ func (context *runtimeContext) ClearWarmInstanceCache() {
 	context.iTracker.UnsetInstance()
 }
 
-// ResetUsedWarmInstances resets the warm instances recorded as used
-func (context *runtimeContext) ResetUsedWarmInstances() {
-	context.iTracker.ResetUsedWarmInstances()
-}
-
 // ReplaceInstanceBuilder replaces the instance builder, allowing the creation
 // of mocked Wasmer instances; this is used for tests only
 func (context *runtimeContext) ReplaceInstanceBuilder(builder arwen.InstanceBuilder) {

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -22,6 +22,8 @@ var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
 const warmCacheSize = 100
 
+const WarmInstancesEnabled = false
+
 type runtimeContext struct {
 	host               arwen.VMHost
 	vmInput            *vmcommon.ContractCallInput
@@ -229,6 +231,10 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 }
 
 func (context *runtimeContext) useWarmInstanceIfExists(gasLimit uint64, newCode bool) bool {
+	if !WarmInstancesEnabled {
+		return false
+	}
+
 	codeHash := context.iTracker.CodeHash()
 	if newCode || len(codeHash) == 0 {
 		return false
@@ -292,6 +298,10 @@ func (context *runtimeContext) saveCompiledCode() {
 }
 
 func (context *runtimeContext) saveWarmInstance() {
+	if !WarmInstancesEnabled {
+		return
+	}
+
 	if context.isContractOrCodeHashOnTheStack() {
 		return
 	}

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -20,9 +20,9 @@ var logRuntime = logger.GetOrCreate("arwen/runtime")
 
 var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
-const warmCacheSize = 100
+const warmCacheSize = 10
 
-const WarmInstancesEnabled = false
+const WarmInstancesEnabled = true
 
 type runtimeContext struct {
 	host               arwen.VMHost
@@ -96,6 +96,11 @@ func (context *runtimeContext) InitState() {
 func (context *runtimeContext) ClearWarmInstanceCache() {
 	context.iTracker.ClearWarmInstanceCache()
 	context.iTracker.UnsetInstance()
+}
+
+// ResetUsedWarmInstances resets the warm instances recorded as used
+func (context *runtimeContext) ResetUsedWarmInstances() {
+	context.iTracker.ResetUsedWarmInstances()
 }
 
 // ReplaceInstanceBuilder replaces the instance builder, allowing the creation

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -353,6 +353,9 @@ func (context *runtimeContext) saveWarmInstance() {
 			context.instance,
 			1,
 		)
+	} else {
+		context.updateNumRunningInstances(-1)
+		logRuntime.Trace("warm instance already in cache", "id", context.instance.Id())
 	}
 
 	lenCacheAfterSaving := context.warmInstanceCache.Len()

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -20,9 +20,9 @@ var logRuntime = logger.GetOrCreate("arwen/runtime")
 
 var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
-const warmCacheSize = 10
+const warmCacheSize = 50
 
-const WarmInstancesEnabled = true
+const WarmInstancesEnabled = false
 
 type runtimeContext struct {
 	host               arwen.VMHost

--- a/arwen/contexts/runtime_test.go
+++ b/arwen/contexts/runtime_test.go
@@ -230,7 +230,7 @@ func TestRuntimeContext_PushPopInstance(t *testing.T) {
 	instance := runtimeContext.instance
 
 	runtimeContext.pushInstance()
-	runtimeContext.instance = nil
+	runtimeContext.instance = &wasmer.Instance{}
 	require.Equal(t, 1, len(runtimeContext.instanceStack))
 
 	runtimeContext.popInstance()

--- a/arwen/contexts/runtime_test.go
+++ b/arwen/contexts/runtime_test.go
@@ -227,19 +227,19 @@ func TestRuntimeContext_PushPopInstance(t *testing.T) {
 	err := runtimeContext.StartWasmerInstance(contractCode, gasLimit, false)
 	require.Nil(t, err)
 
-	instance := runtimeContext.instance
+	instance := runtimeContext.iTracker.instance
 
 	runtimeContext.pushInstance()
-	runtimeContext.instance = &wasmer.Instance{}
-	require.Equal(t, 1, len(runtimeContext.instanceStack))
+	runtimeContext.iTracker.instance = &wasmer.Instance{}
+	require.Equal(t, 1, len(runtimeContext.iTracker.instanceStack))
 
 	runtimeContext.popInstance()
-	require.NotNil(t, runtimeContext.instance)
-	require.Equal(t, instance, runtimeContext.instance)
-	require.Equal(t, 0, len(runtimeContext.instanceStack))
+	require.NotNil(t, runtimeContext.iTracker.instance)
+	require.Equal(t, instance, runtimeContext.iTracker.instance)
+	require.Equal(t, 0, len(runtimeContext.iTracker.instanceStack))
 
 	runtimeContext.pushInstance()
-	require.Equal(t, 1, len(runtimeContext.instanceStack))
+	require.Equal(t, 1, len(runtimeContext.iTracker.instanceStack))
 }
 
 func TestRuntimeContext_PushPopState(t *testing.T) {
@@ -265,7 +265,7 @@ func TestRuntimeContext_PushPopState(t *testing.T) {
 		Function:      funcName,
 	}
 	runtimeContext.InitStateFromContractCallInput(input)
-	runtimeContext.instance = &wasmer.Instance{}
+	runtimeContext.iTracker.instance = &wasmer.Instance{}
 	runtimeContext.PushState()
 	require.Equal(t, 1, len(runtimeContext.stateStack))
 
@@ -287,11 +287,11 @@ func TestRuntimeContext_PushPopState(t *testing.T) {
 	require.False(t, runtimeContext.ReadOnly())
 	require.Nil(t, runtimeContext.Arguments())
 
-	runtimeContext.instance = &wasmer.Instance{}
+	runtimeContext.iTracker.instance = &wasmer.Instance{}
 	runtimeContext.PushState()
 	require.Equal(t, 1, len(runtimeContext.stateStack))
 
-	runtimeContext.instance = &wasmer.Instance{}
+	runtimeContext.iTracker.instance = &wasmer.Instance{}
 	runtimeContext.PushState()
 	require.Equal(t, 2, len(runtimeContext.stateStack))
 
@@ -343,7 +343,7 @@ func TestRuntimeContext_Instance(t *testing.T) {
 	require.NotNil(t, initFunc)
 
 	runtimeContext.ClearWarmInstanceCache()
-	require.Nil(t, runtimeContext.instance)
+	require.Nil(t, runtimeContext.iTracker.instance)
 }
 
 func TestRuntimeContext_Breakpoints(t *testing.T) {
@@ -420,7 +420,7 @@ func TestRuntimeContext_MemLoadStoreOk(t *testing.T) {
 	err := runtimeContext.StartWasmerInstance(contractCode, gasLimit, false)
 	require.Nil(t, err)
 
-	memory := runtimeContext.instance.GetMemory()
+	memory := runtimeContext.iTracker.instance.GetMemory()
 
 	memContents, err := runtimeContext.MemLoad(10, 10)
 	require.Nil(t, err)
@@ -452,7 +452,7 @@ func TestRuntimeContext_MemoryIsBlank(t *testing.T) {
 	err := runtimeContext.StartWasmerInstance(contractCode, gasLimit, false)
 	require.Nil(t, err)
 
-	memory := runtimeContext.instance.GetMemory()
+	memory := runtimeContext.iTracker.instance.GetMemory()
 	totalPages := 2
 	memoryContents := memory.Data()
 	require.Equal(t, memory.Length(), uint32(len(memoryContents)))
@@ -479,7 +479,7 @@ func TestRuntimeContext_MemLoadCases(t *testing.T) {
 	err := runtimeContext.StartWasmerInstance(contractCode, gasLimit, false)
 	require.Nil(t, err)
 
-	memory := runtimeContext.instance.GetMemory()
+	memory := runtimeContext.iTracker.instance.GetMemory()
 
 	var offset int32
 	var length int32
@@ -543,7 +543,7 @@ func TestRuntimeContext_MemStoreCases(t *testing.T) {
 	err := runtimeContext.StartWasmerInstance(contractCode, gasLimit, false)
 	require.Nil(t, err)
 
-	memory := runtimeContext.instance.GetMemory()
+	memory := runtimeContext.iTracker.instance.GetMemory()
 	require.Equal(t, 2*arwen.WASMPageSize, int(memory.Length()))
 
 	// Bad lower bounds
@@ -597,7 +597,7 @@ func TestRuntimeContext_MemStoreForbiddenGrowth(t *testing.T) {
 	err := runtimeContext.StartWasmerInstance(contractCode, gasLimit, false)
 	require.Nil(t, err)
 
-	memory := runtimeContext.instance.GetMemory()
+	memory := runtimeContext.iTracker.instance.GetMemory()
 	require.Equal(t, 2*arwen.WASMPageSize, int(memory.Length()))
 
 	memContents := []byte("test data")
@@ -641,7 +641,7 @@ func TestRuntimeContext_MemLoadStoreVsInstanceStack(t *testing.T) {
 
 	// Push the current instance down the instance stack
 	runtimeContext.pushInstance()
-	require.Equal(t, 1, len(runtimeContext.instanceStack))
+	require.Equal(t, 1, len(runtimeContext.iTracker.instanceStack))
 
 	// Create a new Wasmer instance
 	contractCode = arwen.GetSCCode(path)
@@ -659,7 +659,7 @@ func TestRuntimeContext_MemLoadStoreVsInstanceStack(t *testing.T) {
 
 	// Pop the initial instance from the stack, making it the 'current instance'
 	runtimeContext.popInstance()
-	require.Equal(t, 0, len(runtimeContext.instanceStack))
+	require.Equal(t, 0, len(runtimeContext.iTracker.instanceStack))
 
 	// Check whether the previously-written string "test data1" is still in the
 	// memory of the initial instance

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -354,7 +354,6 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 			if r != nil {
 				log.Error("VM execution panicked", "error", r, "stack", "\n"+string(debug.Stack()))
 				err = arwen.ErrExecutionPanicked
-				host.Runtime().ResetUsedWarmInstances()
 				host.Runtime().CleanInstance()
 			}
 
@@ -415,7 +414,6 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 			if r != nil {
 				log.Error("VM execution panicked", "error", r, "stack", "\n"+string(debug.Stack()))
 				err = arwen.ErrExecutionPanicked
-				host.Runtime().ResetUsedWarmInstances()
 				host.Runtime().CleanInstance()
 			}
 

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -354,6 +354,7 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 			if r != nil {
 				log.Error("VM execution panicked", "error", r, "stack", "\n"+string(debug.Stack()))
 				err = arwen.ErrExecutionPanicked
+				host.Runtime().ResetUsedWarmInstances()
 				host.Runtime().CleanInstance()
 			}
 
@@ -414,6 +415,7 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 			if r != nil {
 				log.Error("VM execution panicked", "error", r, "stack", "\n"+string(debug.Stack()))
 				err = arwen.ErrExecutionPanicked
+				host.Runtime().ResetUsedWarmInstances()
 				host.Runtime().CleanInstance()
 			}
 

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -370,6 +370,10 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 			"returnCode", vmOutput.ReturnCode,
 			"returnMessage", vmOutput.ReturnMessage,
 			"gasRemaining", vmOutput.GasRemaining)
+
+		numWarmInstances, numColdInstances := host.Runtime().NumRunningInstances()
+		log.Trace("RunSmartContractCreate end instances", "warm", numWarmInstances, "cold", numColdInstances)
+
 		host.logFromGasTracer("init")
 	}()
 
@@ -433,6 +437,10 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 			"returnCode", vmOutput.ReturnCode,
 			"returnMessage", vmOutput.ReturnMessage,
 			"gasRemaining", vmOutput.GasRemaining)
+
+		numWarmInstances, numColdInstances := host.Runtime().NumRunningInstances()
+		log.Trace("RunSmartContractCall end instances", "warm", numWarmInstances, "cold", numColdInstances)
+
 		host.logFromGasTracer(input.Function)
 	}()
 

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -94,7 +94,6 @@ func (host *vmHost) performCodeDeployment(input arwen.CodeDeployInput) (*vmcommo
 	}
 
 	defer func() {
-		runtime.ResetUsedWarmInstances()
 		if !contexts.WarmInstancesEnabled {
 			runtime.CleanInstance()
 		}
@@ -222,7 +221,6 @@ func (host *vmHost) doRunSmartContractCall(input *vmcommon.ContractCallInput) *v
 	}
 
 	defer func() {
-		runtime.ResetUsedWarmInstances()
 		if !contexts.WarmInstancesEnabled {
 			runtime.CleanInstance()
 		}

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -13,6 +13,7 @@ import (
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/elrond-vm-common/parsers"
 	"github.com/ElrondNetwork/wasm-vm-v1_4/arwen"
+	"github.com/ElrondNetwork/wasm-vm-v1_4/arwen/contexts"
 	"github.com/ElrondNetwork/wasm-vm-v1_4/math"
 )
 
@@ -92,6 +93,12 @@ func (host *vmHost) performCodeDeployment(input arwen.CodeDeployInput) (*vmcommo
 		return nil, arwen.ErrContractInvalid
 	}
 
+	defer func() {
+		if !contexts.WarmInstancesEnabled {
+			runtime.CleanInstance()
+		}
+	}()
+
 	err = host.callInitFunction()
 	if err != nil {
 		return nil, err
@@ -103,6 +110,7 @@ func (host *vmHost) performCodeDeployment(input arwen.CodeDeployInput) (*vmcommo
 	}
 
 	vmOutput := output.GetVMOutput()
+
 	return vmOutput, nil
 }
 
@@ -211,6 +219,12 @@ func (host *vmHost) doRunSmartContractCall(input *vmcommon.ContractCallInput) *v
 		vmOutput = output.CreateVMOutputInCaseOfError(arwen.ErrContractInvalid)
 		return vmOutput
 	}
+
+	defer func() {
+		if !contexts.WarmInstancesEnabled {
+			runtime.CleanInstance()
+		}
+	}()
 
 	err = host.callSCMethod()
 	if err != nil {

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -94,6 +94,7 @@ func (host *vmHost) performCodeDeployment(input arwen.CodeDeployInput) (*vmcommo
 	}
 
 	defer func() {
+		runtime.ResetUsedWarmInstances()
 		if !contexts.WarmInstancesEnabled {
 			runtime.CleanInstance()
 		}
@@ -221,6 +222,7 @@ func (host *vmHost) doRunSmartContractCall(input *vmcommon.ContractCallInput) *v
 	}
 
 	defer func() {
+		runtime.ResetUsedWarmInstances()
 		if !contexts.WarmInstancesEnabled {
 			runtime.CleanInstance()
 		}

--- a/arwen/hosttest/execution_benchmark_test.go
+++ b/arwen/hosttest/execution_benchmark_test.go
@@ -128,6 +128,8 @@ func runERC20Benchmark(tb testing.TB, nTransfers int, nRuns int, failTransaction
 	}
 
 	defer func() {
+		_, numColdInstances := host.Runtime().NumRunningInstances()
+		require.Zero(tb, numColdInstances)
 		host.Reset()
 	}()
 }
@@ -138,6 +140,8 @@ func runMemoryUsageFuzzyBenchmark(tb testing.TB, nContracts int, nTransfers int)
 	require.Nil(tb, err)
 
 	defer func() {
+		_, numColdInstances := host.Runtime().NumRunningInstances()
+		require.Zero(tb, numColdInstances)
 		host.Reset()
 	}()
 
@@ -194,6 +198,8 @@ func runMemoryUsageBenchmark(tb testing.TB, nContracts int, nTransfers int) {
 	require.Nil(tb, err)
 
 	defer func() {
+		_, numColdInstances := host.Runtime().NumRunningInstances()
+		require.Zero(tb, numColdInstances)
 		host.Reset()
 	}()
 

--- a/arwen/hosttest/wasmer_test.go
+++ b/arwen/hosttest/wasmer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/wasm-vm-v1_4/arwen"
+	"github.com/ElrondNetwork/wasm-vm-v1_4/arwen/contexts"
 	contextmock "github.com/ElrondNetwork/wasm-vm-v1_4/mock/context"
 	worldmock "github.com/ElrondNetwork/wasm-vm-v1_4/mock/world"
 	test "github.com/ElrondNetwork/wasm-vm-v1_4/testcommon"
@@ -237,6 +238,10 @@ func TestWASMMemories_MultipleMemories(t *testing.T) {
 }
 
 func TestWASMMemories_ResetContent(t *testing.T) {
+	if !contexts.WarmInstancesEnabled {
+		t.Skip("test only relevant with warm instances")
+	}
+
 	testCase := test.BuildInstanceCallTest(t).
 		WithContracts(
 			test.CreateInstanceContract(test.ParentAddress).
@@ -263,6 +268,10 @@ func TestWASMMemories_ResetContent(t *testing.T) {
 }
 
 func TestWASMMemories_ResetDataInitializers(t *testing.T) {
+	if !contexts.WarmInstancesEnabled {
+		t.Skip("test only relevant with warm instances")
+	}
+
 	testCase := test.BuildInstanceCallTest(t).
 		WithContracts(
 			test.CreateInstanceContract(test.ParentAddress).

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -138,6 +138,7 @@ type RuntimeContext interface {
 	SetReadOnly(readOnly bool)
 	StartWasmerInstance(contract []byte, gasLimit uint64, newCode bool) error
 	ClearWarmInstanceCache()
+	ResetUsedWarmInstances()
 	SetMaxInstanceCount(uint64)
 	VerifyContractCode() error
 	GetInstance() wasmer.InstanceHandler

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -157,6 +157,7 @@ type RuntimeContext interface {
 	ManagedBufferAPIErrorShouldFailExecution() bool
 	ExecuteAsyncCall(address []byte, data []byte, value []byte) error
 	CleanInstance()
+	NumRunningInstances() (int, int)
 	AddError(err error, otherInfo ...string)
 	GetAllErrors() error
 	ReplaceInstanceBuilder(builder InstanceBuilder)

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -138,7 +138,6 @@ type RuntimeContext interface {
 	SetReadOnly(readOnly bool)
 	StartWasmerInstance(contract []byte, gasLimit uint64, newCode bool) error
 	ClearWarmInstanceCache()
-	ResetUsedWarmInstances()
 	SetMaxInstanceCount(uint64)
 	VerifyContractCode() error
 	GetInstance() wasmer.InstanceHandler

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -107,6 +107,11 @@ func (instance *InstanceMock) Clean() bool {
 	return true
 }
 
+// AlreadyCleaned mocked method
+func (instance *InstanceMock) AlreadyCleaned() bool {
+	return false
+}
+
 // Reset mocked method
 func (instance *InstanceMock) Reset() bool {
 	return true

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -103,7 +103,8 @@ func (instance *InstanceMock) Cache() ([]byte, error) {
 }
 
 // Clean mocked method
-func (instance *InstanceMock) Clean() {
+func (instance *InstanceMock) Clean() bool {
+	return true
 }
 
 // Reset mocked method

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -359,3 +359,7 @@ func (r *RuntimeContextMock) NumRunningInstances() (int, int) {
 // CleanInstance mocked method
 func (r *RuntimeContextMock) CleanInstance() {
 }
+
+// ResetUsedWarmInstances mocked method
+func (r *RuntimeContextMock) ResetUsedWarmInstances() {
+}

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -351,6 +351,11 @@ func (r *RuntimeContextMock) GetAllErrors() error {
 	return nil
 }
 
+// NumRunningInstances -
+func (r *RuntimeContextMock) NumRunningInstances() (int, int) {
+	return 0, 0
+}
+
 // CleanInstance mocked method
 func (r *RuntimeContextMock) CleanInstance() {
 }

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -359,7 +359,3 @@ func (r *RuntimeContextMock) NumRunningInstances() (int, int) {
 // CleanInstance mocked method
 func (r *RuntimeContextMock) CleanInstance() {
 }
-
-// ResetUsedWarmInstances mocked method
-func (r *RuntimeContextMock) ResetUsedWarmInstances() {
-}

--- a/mock/context/runtimeContextWrapper.go
+++ b/mock/context/runtimeContextWrapper.go
@@ -658,3 +658,8 @@ func (contextWrapper *RuntimeContextWrapper) ClearStateStack() {
 func (contextWrapper *RuntimeContextWrapper) CleanInstance() {
 	contextWrapper.CleanInstanceFunc()
 }
+
+// NumRunningInstances -
+func (contextWrapper *RuntimeContextWrapper) NumRunningInstances() (int, int) {
+	return 0, 0
+}

--- a/mock/context/runtimeContextWrapper.go
+++ b/mock/context/runtimeContextWrapper.go
@@ -659,6 +659,10 @@ func (contextWrapper *RuntimeContextWrapper) CleanInstance() {
 	contextWrapper.CleanInstanceFunc()
 }
 
+// ResetUsedWarmInstances mocked method
+func (r *RuntimeContextWrapper) ResetUsedWarmInstances() {
+}
+
 // NumRunningInstances -
 func (contextWrapper *RuntimeContextWrapper) NumRunningInstances() (int, int) {
 	return 0, 0

--- a/mock/context/runtimeContextWrapper.go
+++ b/mock/context/runtimeContextWrapper.go
@@ -659,10 +659,6 @@ func (contextWrapper *RuntimeContextWrapper) CleanInstance() {
 	contextWrapper.CleanInstanceFunc()
 }
 
-// ResetUsedWarmInstances mocked method
-func (r *RuntimeContextWrapper) ResetUsedWarmInstances() {
-}
-
 // NumRunningInstances -
 func (contextWrapper *RuntimeContextWrapper) NumRunningInstances() (int, int) {
 	return 0, 0

--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -127,11 +127,11 @@ func runTestWithInstances(callerTest *InstancesTestTemplate, reset bool) {
 	defer func() {
 		if reset {
 			callerTest.host.Reset()
-
-			// Extra verification for instance leaks
-			_, numColdInstances := callerTest.host.Runtime().NumRunningInstances()
-			require.Zero(callerTest.tb, numColdInstances, "number of instances leaked")
 		}
+
+		// Extra verification for instance leaks
+		_, numColdInstances := callerTest.host.Runtime().NumRunningInstances()
+		require.Zero(callerTest.tb, numColdInstances, "number of instances leaked")
 	}()
 
 	vmOutput, err := callerTest.host.RunSmartContractCall(callerTest.input)

--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ElrondNetwork/wasm-vm-v1_4/arwen"
 	"github.com/ElrondNetwork/wasm-vm-v1_4/config"
 	contextmock "github.com/ElrondNetwork/wasm-vm-v1_4/mock/context"
+	"github.com/stretchr/testify/require"
 )
 
 // InstanceTestSmartContract represents the config data for the smart contract instance to be tested
@@ -135,5 +136,9 @@ func runTestWithInstances(callerTest *InstancesTestTemplate, reset bool) {
 		allErrors := callerTest.host.Runtime().GetAllErrors()
 		verify := NewVMOutputVerifierWithAllErrors(callerTest.tb, vmOutput, err, allErrors)
 		callerTest.assertResults(callerTest.host, callerTest.blockchainHookStub, verify)
+
+		// Extra verification for instance leaks
+		_, numColdInstances := callerTest.host.Runtime().NumRunningInstances()
+		require.Zero(callerTest.tb, numColdInstances)
 	}
 }

--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -127,6 +127,10 @@ func runTestWithInstances(callerTest *InstancesTestTemplate, reset bool) {
 	defer func() {
 		if reset {
 			callerTest.host.Reset()
+
+			// Extra verification for instance leaks
+			_, numColdInstances := callerTest.host.Runtime().NumRunningInstances()
+			require.Zero(callerTest.tb, numColdInstances, "number of instances leaked")
 		}
 	}()
 
@@ -136,9 +140,5 @@ func runTestWithInstances(callerTest *InstancesTestTemplate, reset bool) {
 		allErrors := callerTest.host.Runtime().GetAllErrors()
 		verify := NewVMOutputVerifierWithAllErrors(callerTest.tb, vmOutput, err, allErrors)
 		callerTest.assertResults(callerTest.host, callerTest.blockchainHookStub, verify)
-
-		// Extra verification for instance leaks
-		_, numColdInstances := callerTest.host.Runtime().NumRunningInstances()
-		require.Zero(callerTest.tb, numColdInstances, "number of instances leaked")
 	}
 }

--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -139,6 +139,6 @@ func runTestWithInstances(callerTest *InstancesTestTemplate, reset bool) {
 
 		// Extra verification for instance leaks
 		_, numColdInstances := callerTest.host.Runtime().NumRunningInstances()
-		require.Zero(callerTest.tb, numColdInstances)
+		require.Zero(callerTest.tb, numColdInstances, "number of instances leaked")
 	}
 }

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -113,7 +113,7 @@ type Instance struct {
 
 	InstanceCtx InstanceContext
 
-	alreadyCleaned bool
+	AlreadyClean bool
 }
 
 type CompilationOptions struct {
@@ -267,7 +267,7 @@ func (instance *Instance) SetContextData(data uintptr) {
 // Clean cleans instance
 func (instance *Instance) Clean() bool {
 	logWasmer.Trace("cleaning instance", "id", instance.Id())
-	if instance.alreadyCleaned {
+	if instance.AlreadyClean {
 		logWasmer.Trace("clean: already cleaned instance", "id", instance.Id())
 		return false
 	}
@@ -279,7 +279,7 @@ func (instance *Instance) Clean() bool {
 			instance.Memory.Destroy()
 		}
 
-		instance.alreadyCleaned = true
+		instance.AlreadyClean = true
 		logWasmer.Trace("cleaned instance", "id", instance.Id())
 
 		return true
@@ -288,9 +288,9 @@ func (instance *Instance) Clean() bool {
 	return false
 }
 
-// AlreadyCleaned returns the internal field alreadyCleaned
+// AlreadyCleaned returns the internal field AlreadyClean
 func (instance *Instance) AlreadyCleaned() bool {
-	return instance.alreadyCleaned
+	return instance.AlreadyClean
 }
 
 // GetPointsUsed returns the internal instance gas counter
@@ -378,7 +378,7 @@ func (instance *Instance) GetMemory() MemoryHandler {
 
 // Reset resets the instance memories and globals
 func (instance *Instance) Reset() bool {
-	if instance.alreadyCleaned {
+	if instance.AlreadyClean {
 		logWasmer.Trace("reset: already cleaned instance", "id", instance.Id())
 		return false
 	}

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -265,11 +265,11 @@ func (instance *Instance) SetContextData(data uintptr) {
 }
 
 // Clean cleans instance
-func (instance *Instance) Clean() {
+func (instance *Instance) Clean() bool {
 	logWasmer.Trace("cleaning instance", "id", instance.Id())
 	if instance.alreadyCleaned {
 		logWasmer.Trace("clean: already cleaned instance", "id", instance.Id())
-		return
+		return false
 	}
 
 	if instance.instance != nil {
@@ -281,7 +281,11 @@ func (instance *Instance) Clean() {
 
 		instance.alreadyCleaned = true
 		logWasmer.Trace("cleaned instance", "id", instance.Id())
+
+		return true
 	}
+
+	return false
 }
 
 // GetPointsUsed returns the internal instance gas counter

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -288,6 +288,11 @@ func (instance *Instance) Clean() bool {
 	return false
 }
 
+// AlreadyCleaned returns the internal field alreadyCleaned
+func (instance *Instance) AlreadyCleaned() bool {
+	return instance.alreadyCleaned
+}
+
 // GetPointsUsed returns the internal instance gas counter
 func (instance *Instance) GetPointsUsed() uint64 {
 	return cWasmerInstanceGetPointsUsed(instance.instance)

--- a/wasmer/interface.go
+++ b/wasmer/interface.go
@@ -11,6 +11,7 @@ type InstanceHandler interface {
 	GetBreakpointValue() uint64
 	Cache() ([]byte, error)
 	Clean() bool
+	AlreadyCleaned() bool
 	GetExports() ExportsMap
 	GetSignature(functionName string) (*ExportedFunctionSignature, bool)
 	GetData() uintptr

--- a/wasmer/interface.go
+++ b/wasmer/interface.go
@@ -10,7 +10,7 @@ type InstanceHandler interface {
 	SetBreakpointValue(value uint64)
 	GetBreakpointValue() uint64
 	Cache() ([]byte, error)
-	Clean()
+	Clean() bool
 	GetExports() ExportsMap
 	GetSignature(functionName string) (*ExportedFunctionSignature, bool)
 	GetData() uintptr


### PR DESCRIPTION
This PR refactors the RuntimeContext implementation, adding a new subcomponent called `instanceTracker`. The instance tracker isolates the Wasmer instances from the RuntimeContext, counts them and can warn whether an entire instance is leaked.

The `warmInstanceCache` is now part of the instance tracker. The instance tracker fixes two minor instance leaks and adds helpful `TRACE` logs, but does not yet fix the primary memory leak remaining.

The PR also adds a global switch that can turn warm instances off completely. Required until the memory leak is fixed.